### PR TITLE
Shift support to recent Coq.

### DIFF
--- a/autoload/python/coqide/session.py
+++ b/autoload/python/coqide/session.py
@@ -20,7 +20,7 @@ class Session:
         self._vim = vim
         self._worker = worker
 
-        self._coqtop.spawn(['coqtop', '-ideslave', '-main-channel', 'stdfds',
+        self._coqtop.spawn(['coqidetop', '-main-channel', 'stdfds',
                             '-async-proofs', 'on'])
         self._stm.init()
 


### PR DESCRIPTION
Since Coq 8.9.0, one should command `coqidetop` instead of
`coqtop-ideslave`. This commit delivers that change. Unfortunately,
it makes the plugin incompatible with earlier versions of Coq.